### PR TITLE
[TimerList] use a multiple of item height for the widget height

### DIFF
--- a/usr/share/enigma2/E2-DarkOS/skin.xml
+++ b/usr/share/enigma2/E2-DarkOS/skin.xml
@@ -1379,7 +1379,7 @@
   <screen name="TimerEditList" position="fill" title="Timer Overview" flags="wfNoBorder" backgroundColor="transparent">
     <panel name="Screen_Menu1" />
     <panel name="keyInfo_Menu1" />
-    <widget name="timerlist" position="396,210" size="1130,500" scrollbarMode="showNever" itemHeight="90" iconMargin="20" rowSplit="42" setEventNameFont="Regular;32" setServiceNameFont="Regular;28" setFont="Regular;28" satPosLeft="250" />
+    <widget name="timerlist" position="396,210" size="1130,5*90" scrollbarMode="showNever" itemHeight="90" iconMargin="20" rowSplit="42" setEventNameFont="Regular;32" setServiceNameFont="Regular;28" setFont="Regular;28" satPosLeft="250" />
     <widget addon="Pager" connection="timerlist" position="396,734" size="1130,25" transparent="1" backgroundColor="background" pagerForeground="white" pagerBackground="background" />
     <widget name="description" position="395,776" size="1130,80" backgroundColor="background" font="Regular;30" halign="center" />
   </screen>


### PR DESCRIPTION
Still to do...

Selection background image not wide enough.
Pager widget not showing on screen.

< 30239.9494> [Skin] Attribute 'pagerForeground' (with value of 'white') in object of type 'eListbox' is not implemented! < 30239.9498> [Skin] Attribute 'pagerBackground' (with value of 'background') in object of type 'eListbox' is not implemented!